### PR TITLE
Pin mcp<2.0.0 across all servers

### DIFF
--- a/servers/bls-oews-mcp/pyproject.toml
+++ b/servers/bls-oews-mcp/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/ecfr-mcp/pyproject.toml
+++ b/servers/ecfr-mcp/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/federal-register-mcp/pyproject.toml
+++ b/servers/federal-register-mcp/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/gsa-calc-mcp/pyproject.toml
+++ b/servers/gsa-calc-mcp/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/gsa-perdiem-mcp/pyproject.toml
+++ b/servers/gsa-perdiem-mcp/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/regulations-gov-mcp/pyproject.toml
+++ b/servers/regulations-gov-mcp/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/sam-gov-mcp/pyproject.toml
+++ b/servers/sam-gov-mcp/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 

--- a/servers/usaspending-gov-mcp/pyproject.toml
+++ b/servers/usaspending-gov-mcp/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 


### PR DESCRIPTION
## What this fixes

All eight servers declare `"mcp>=1.0.0"` with no upper bound. The official MCP Python SDK released 2.0.0 on 2026-07-28, which removed the `mcp.server.fastmcp` module that every server imports. Any resolver run after that date picks 2.0.0, and all eight crash on startup.

This affects every new install via `uvx` or `pip`. Existing installs with a warm cache keep working until it's cleared, which makes the failure look intermittent.

## The failure

```
uvx ecfr-mcp
```

```
Installed 34 packages in 637ms
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "...\Lib\site-packages\ecfr_mcp\server.py", line 22, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

In 2.0.0 the class was renamed and relocated to `mcp.server.mcpserver.MCPServer`. The old import path was removed, not deprecated.

Migration reference: https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md

## The change

One line per `pyproject.toml`, eight files:

```diff
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
```

No other changes.

## Verification

Confirmed 1.29.0 resolves and imports cleanly:

```
uv venv .venv --python 3.12
uv pip install --python .\.venv\Scripts\python.exe -e .
uv pip install --python .\.venv\Scripts\python.exe mcp==1.29.0
.\.venv\Scripts\python.exe -c "from mcp.server.fastmcp import FastMCP; print('ok')"
# ok
```

After the pin, all eight servers build from source and register in Claude Desktop. Smoke-tested each one against its live API:

| Server | Check |
|---|---|
| ecfr | 38 CFR 4.88a full text retrieved |
| federal-register | VA final rules since 2026-06-01 |
| gsa-calc | IGCE benchmark, 5,201 rate records |
| gsa-perdiem | Monterey CA FY2026 rates |
| usaspending | VA FY2025 obligations by category |
| sam-gov | Entity search, 47 records |
| regulations-gov | VA proposed rules, 2026 |
| bls-oews | National wage data, SOC 15-1252 |

Reproduced on Python 3.12.13 and 3.14, Windows 11.

## Notes

This is the minimal fix to unbreak installs. The longer-term options are migrating imports to the 2.x API and widening the bound, or moving to the standalone `fastmcp` package, which keeps the `FastMCP` name and is versioned independently.

A CI job that installs the newest `mcp` would catch this class of regression at PR time.
