### PR TITLE
Block stale package versions and gate PyPI on hosted deployment

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -44,6 +44,9 @@ jobs:
           --with "${{ matrix.filelock }}" --with platformdirs
           pytest -q tests/test_federal_api_pacing.py
 
+      - name: Test release safeguards
+        run: uv run --with pytest --with packaging --with pyyaml pytest -q tests/test_release_guards.py
+
       - name: Verify version surfaces
         run: python scripts/validate_versions.py
 
@@ -92,7 +95,7 @@ jobs:
         run: uv run pytest -q
 
       - name: Install build tooling
-        run: pip install --upgrade build
+        run: pip install --upgrade build packaging
 
       - name: Build sdist + wheel
         working-directory: servers/${{ matrix.server.dir }}
@@ -102,6 +105,9 @@ jobs:
         working-directory: servers/${{ matrix.server.dir }}
         run: unzip -l dist/*.whl | grep '_pacing.py'
 
+      - name: Reject changed packages using an existing PyPI version
+        run: python scripts/check_published_version.py servers/${{ matrix.server.dir }}
+
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:
@@ -109,7 +115,7 @@ jobs:
           path: servers/${{ matrix.server.dir }}/dist/
 
   publish:
-    needs: [test-and-build, hosted-build, cloudflare-access]
+    needs: [test-and-build, hosted-build, cloudflare-access, deploy-hosted]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -125,8 +131,14 @@ jobs:
           - { dir: "sam-gov-mcp",         pkg: "sam-gov-mcp" }
           - { dir: "usaspending-gov-mcp", pkg: "usaspending-gov-mcp" }
     permissions:
+      contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v6
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:
@@ -138,6 +150,9 @@ jobs:
         with:
           packages-dir: dist/
           skip-existing: true
+
+      - name: Verify actual published package matches the built wheel
+        run: uv run --with packaging python scripts/check_published_version.py servers/${{ matrix.server.dir }} --dist dist --require-published
 
   publish-registry:
     needs: publish

--- a/.github/workflows/release-guard-checks.yml
+++ b/.github/workflows/release-guard-checks.yml
@@ -1,0 +1,42 @@
+name: Release guard checks
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish-pypi.yml'
+      - '.github/workflows/release-guard-checks.yml'
+      - 'scripts/check_published_version.py'
+      - 'tests/test_release_guards.py'
+      - 'servers/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-pypi.yml'
+      - '.github/workflows/release-guard-checks.yml'
+      - 'scripts/check_published_version.py'
+      - 'tests/test_release_guards.py'
+      - 'servers/**'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v6
+      - name: Exercise version and release-order failure cases
+        run: uv run --with pytest --with packaging --with pyyaml pytest -q tests/test_release_guards.py
+      - name: Build and compare all nine packages with PyPI
+        run: |
+          for project in servers/*; do
+            test -f "$project/pyproject.toml" || continue
+            dist="$RUNNER_TEMP/dist-$(basename "$project")"
+            uv build "$project" --out-dir "$dist"
+            uv run --with packaging python scripts/check_published_version.py "$project" --dist "$dist"
+          done

--- a/docs/unified-release.md
+++ b/docs/unified-release.md
@@ -6,9 +6,10 @@ edits do not deploy production.
 
 ```text
 release tag -> shared tests + package tests + hosted image/contract checks
-                 -> PyPI packages
+                 -> published-version guard for all nine packages
                  -> Cloudflare hosted services -> live verification
-                 -> MCP registry (after PyPI)
+                 -> PyPI packages -> verify published wheels
+                 -> MCP registry
                  -> final release and destination summary
 ```
 
@@ -23,12 +24,21 @@ does not publish website content or submit directory listings.
 - `deploy/<service>/` owns the Worker wrapper, frozen container build, and npm lock.
 - Keep the existing `publish-pypi.yml` filename: PyPI Trusted Publishers refer to it.
 - Patch package versions, manifests, and Docker install pins for changed packages.
-  `scripts/validate_versions.py` checks them. Unchanged versions are skipped by the
-  existing PyPI and registry publishing steps.
+  `scripts/validate_versions.py` checks internal version consistency. Before any
+  deployment, `scripts/check_published_version.py` compares each built wheel
+  against the same version on PyPI: installed payload, dependency/Python metadata,
+  extras, entry points, and wheel compatibility must match. Changed packages must
+  use a new version above the latest PyPI release. Unchanged packages may be
+  skipped safely. ZIP timestamps, builder metadata, and README prose do not force
+  a bump. This compares declared package dependencies, not hosted lockfile pins.
+  PyPI outages, missing artifacts for an existing version, yanked matching wheels,
+  or checksum failures stop release. The guard is repeated after publication with
+  `--require-published`, including skipped versions, to check actual PyPI contents.
 - Push a new `v*` tag only after review and tests. Manual workflow dispatch on a tag
   supports retries. Never overlap a legacy release with the first unified release.
-- The workflow serializes unified production releases. PyPI and Cloudflare may
-  complete at different times; a partial failure is reported as a failed release.
+- The workflow serializes unified production releases. Cloudflare deployment and
+  live verification must succeed for all five services before PyPI starts.
+  A partial failure is reported as a failed release.
   It is not a transaction, and PyPI versions cannot be overwritten or rolled back.
 
 ## Credentials and first activation
@@ -38,7 +48,9 @@ named `CLOUDFLARE_API_TOKEN`. GitHub's hosted runners cannot read a Mac's Keycha
 Use a dedicated Cloudflare account token with Account Settings Read, Workers
 Scripts Write, and Workers Containers Write for account
 `846d3e41e48446abcd3570c0959f9fb5`, plus Zone Read and Workers Routes Write scoped
-to the `1102tools.com` zone. Confirm effective permissions with the preflight.
+to the `1102tools.com` zone. The read-only preflight verifies container-list
+access, not every deployment permission. Successful deployment and live
+verification are the enforced gate before any PyPI upload.
 Do not copy the broader interactive Keychain token into CI, log credentials, or
 commit them. PyPI continues using OIDC Trusted Publishing, without a PyPI API key.
 The existing `mcp-registry-publish` environment retains its own registry secret.
@@ -70,8 +82,13 @@ response reports the release commit. After rollout, the pipeline verifies that
 commit, package version, full tool list, and three real upstream tool requests.
 The overall release succeeds only if PyPI, Cloudflare, and registry jobs succeed.
 
-If publication succeeds but deployment fails, inspect the failed service's log
-and rerun the failed jobs on the same tag. Existing PyPI versions are skipped.
+If Cloudflare deployment or verification fails, PyPI and registry publication
+are skipped. Inspect the failed service and rerun failed jobs on the same tag.
+If PyPI or registry publication fails afterward, hosted services may already
+serve the new release; retry the failed publication jobs. Existing PyPI versions
+are skipped only after the content guard has passed, and checked again afterward.
+Do not overwrite a published version. A successful Cloudflare deployment does
+not make the two destinations transactional.
 Do not mark the release synchronized based only on a successful upload or health
 check. Do not remove or rename a Worker, Container application, or endpoint to
 work around a failed deployment.

--- a/scripts/check_published_version.py
+++ b/scripts/check_published_version.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Fail closed when an existing PyPI version differs from the built wheel.
+
+Compare installed payload and install metadata, not ZIP timestamps, RECORD,
+builder versions, or README prose. No downloaded code is imported or executed.
+"""
+
+import argparse
+import configparser
+from email.parser import BytesParser
+import hashlib
+import io
+import json
+from pathlib import Path
+import time
+import tomllib
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+import zipfile
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+
+class GuardError(RuntimeError):
+    pass
+
+
+def fetch(url, *, missing_ok=False):
+    for attempt in range(3):
+        try:
+            with urlopen(Request(url, headers={"User-Agent": "1102tools-release-guard/1"}), timeout=40) as response:
+                return response.read()
+        except HTTPError as error:
+            if error.code == 404 and missing_ok:
+                return None
+            if error.code != 429 and error.code < 500:
+                raise GuardError(f"PyPI check failed: HTTP {error.code}") from error
+        except (URLError, TimeoutError, OSError):
+            pass
+        if attempt < 2:
+            time.sleep(2 ** attempt)
+    raise GuardError("Cannot verify PyPI after three attempts; refusing to release")
+
+
+def normalized_requirement(value):
+    requirement = Requirement(value)
+    extras = sorted(canonicalize_name(extra) for extra in requirement.extras)
+    return (
+        canonicalize_name(requirement.name), tuple(extras), str(requirement.specifier),
+        requirement.url or "", str(requirement.marker) if requirement.marker else "",
+    )
+
+
+def wheel_contract(data):
+    with zipfile.ZipFile(io.BytesIO(data)) as wheel:
+        names = [name for name in wheel.namelist() if not name.endswith("/")]
+        if len(names) != len(set(names)):
+            raise GuardError("Wheel contains duplicate paths")
+        metadata_paths = [name for name in names if name.endswith(".dist-info/METADATA")]
+        if len(metadata_paths) != 1:
+            raise GuardError("Expected exactly one wheel METADATA file")
+        metadata_path = metadata_paths[0]
+        dist_info = metadata_path.rsplit("/", 1)[0] + "/"
+        metadata = BytesParser().parsebytes(wheel.read(metadata_path))
+        if not metadata["Name"] or not metadata["Version"]:
+            raise GuardError("Wheel is missing its package identity")
+        payload = {
+            name: hashlib.sha256(wheel.read(name)).hexdigest()
+            for name in names if not name.startswith(dist_info)
+        }
+        entries = configparser.ConfigParser(interpolation=None)
+        entries.optionxform = str
+        if dist_info + "entry_points.txt" in names:
+            entries.read_string(wheel.read(dist_info + "entry_points.txt").decode())
+        wheel_metadata = BytesParser().parsebytes(wheel.read(dist_info + "WHEEL"))
+        return {
+            "name": canonicalize_name(metadata["Name"]),
+            "version": str(Version(metadata["Version"])),
+            "payload": payload,
+            "dependencies": sorted(normalized_requirement(value) for value in metadata.get_all("Requires-Dist", [])),
+            "python": str(SpecifierSet(metadata.get("Requires-Python", ""))),
+            "extras": sorted(canonicalize_name(value) for value in metadata.get_all("Provides-Extra", [])),
+            "external": sorted(metadata.get_all("Requires-External", [])),
+            "entry_points": {section: dict(entries.items(section)) for section in entries.sections()},
+            "tags": sorted(wheel_metadata.get_all("Tag", [])),
+            "purelib": wheel_metadata.get("Root-Is-Purelib"),
+        }
+
+
+def check_wheel(path, name, version, *, require_published=False, fetcher=fetch):
+    local = wheel_contract(path.read_bytes())
+    if (local["name"], Version(local["version"])) != (canonicalize_name(name), Version(version)):
+        raise GuardError("Built wheel identity differs from pyproject.toml")
+    base = "https://pypi.org/pypi/" + quote(canonicalize_name(name), safe="")
+    response = fetcher(base + "/" + quote(version, safe="") + "/json", missing_ok=True)
+    if response is None:
+        if require_published:
+            raise GuardError(f"{name} {version} is not published")
+        project = fetcher(base + "/json", missing_ok=True)
+        if project is not None and Version(version) <= Version(json.loads(project)["info"]["version"]):
+            raise GuardError(f"{name}: choose a new version above the latest PyPI release")
+        return "new version"
+    release = json.loads(response)
+    artifacts = [file for file in release["urls"] if file["filename"] == path.name and file["packagetype"] == "bdist_wheel"]
+    if len(artifacts) != 1 or artifacts[0].get("yanked"):
+        raise GuardError(f"{name} {version}: no matching non-yanked published wheel; increase its version")
+    artifact = artifacts[0]
+    url = urlparse(artifact["url"])
+    if url.scheme != "https" or url.hostname != "files.pythonhosted.org":
+        raise GuardError("Unexpected PyPI artifact host")
+    published = fetcher(artifact["url"])
+    if hashlib.sha256(published).hexdigest() != artifact["digests"]["sha256"]:
+        raise GuardError("Published wheel SHA-256 does not match PyPI")
+    remote = wheel_contract(published)
+    differences = [key for key in local if local[key] != remote[key]]
+    if differences:
+        raise GuardError(
+            f"{name} {version}: package changed ({', '.join(differences)}); increase its version"
+        )
+    return "published version matches"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project", type=Path)
+    parser.add_argument("--dist", type=Path)
+    parser.add_argument("--require-published", action="store_true")
+    args = parser.parse_args()
+    project = tomllib.loads((args.project / "pyproject.toml").read_text())["project"]
+    wheels = list((args.dist or args.project / "dist").glob("*.whl"))
+    if len(wheels) != 1:
+        raise GuardError("Expected exactly one built wheel")
+    result = check_wheel(wheels[0], project["name"], project["version"], require_published=args.require_published)
+    print(f"{project['name']} {project['version']}: {result}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (GuardError, ValueError, KeyError, OSError, zipfile.BadZipFile) as error:
+        raise SystemExit(str(error)) from error

--- a/tests/test_release_guards.py
+++ b/tests/test_release_guards.py
@@ -1,0 +1,137 @@
+"""Release regression cases: silent PyPI skips and unsafe deployment ordering."""
+import hashlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+import zipfile
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("guard", ROOT / "scripts/check_published_version.py")
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+
+def wheel(*, code=b"answer = 42\n", requirement="httpx>=0.27", python=">=3.11", entry="demo:main", prose="README", version="1.0.0", extra_file=False, generator="builder 1"):
+    result = io.BytesIO()
+    with zipfile.ZipFile(result, "w") as archive:
+        prefix = f"demo-{version}.dist-info/"
+        archive.writestr("demo/__init__.py", code)
+        if extra_file:
+            archive.writestr("demo/data.json", '{"new": true}')
+        archive.writestr(prefix + "METADATA", f"Metadata-Version: 2.4\nName: demo\nVersion: {version}\nRequires-Python: {python}\nRequires-Dist: {requirement}\n\n{prose}")
+        archive.writestr(prefix + "WHEEL", f"Wheel-Version: 1.0\nGenerator: {generator}\nRoot-Is-Purelib: true\nTag: py3-none-any\n")
+        archive.writestr(prefix + "entry_points.txt", f"[console_scripts]\ndemo = {entry}\n")
+        archive.writestr(prefix + "RECORD", "irrelevant generated record")
+    return result.getvalue()
+
+
+def published_fetcher(data, filename, *, yanked=False, digest=None):
+    def fetch(url, **kwargs):
+        if url.endswith("/json"):
+            return json.dumps({"urls": [{"filename": filename, "packagetype": "bdist_wheel", "yanked": yanked, "url": "https://files.pythonhosted.org/demo.whl", "digests": {"sha256": digest or hashlib.sha256(data).hexdigest()}}]}).encode()
+        return data
+    return fetch
+
+
+def local_wheel(tmp_path, **kwargs):
+    version = kwargs.get("version", "1.0.0")
+    path = tmp_path / f"demo-{version}-py3-none-any.whl"
+    path.write_bytes(wheel(**kwargs))
+    return path
+
+
+def test_unchanged_rebuild_can_be_skipped(tmp_path):
+    path = local_wheel(tmp_path, prose="new README", generator="new builder", requirement="httpx >= 0.27")
+    assert guard.check_wheel(path, "demo", "1.0.0", fetcher=published_fetcher(wheel(), path.name)) == "published version matches"
+
+
+@pytest.mark.parametrize("change", [
+    {"code": b"answer = 43\n"},
+    {"requirement": "httpx>=0.28"},
+    {"python": ">=3.12"},
+    {"entry": "demo:new_main"},
+    {"extra_file": True},
+])
+def test_changed_existing_version_is_rejected(tmp_path, change):
+    path = local_wheel(tmp_path, **change)
+    with pytest.raises(guard.GuardError, match="increase its version"):
+        guard.check_wheel(path, "demo", "1.0.0", fetcher=published_fetcher(wheel(), path.name))
+
+
+def test_new_version_is_accepted_but_cannot_be_reported_as_published(tmp_path):
+    path = local_wheel(tmp_path, version="1.0.1", code=b"changed")
+    def fetch(url, **kwargs):
+        return json.dumps({"info": {"version": "1.0.0"}}).encode() if url.endswith("/demo/json") else None
+    assert guard.check_wheel(path, "demo", "1.0.1", fetcher=fetch) == "new version"
+    with pytest.raises(guard.GuardError, match="not published"):
+        guard.check_wheel(path, "demo", "1.0.1", fetcher=fetch, require_published=True)
+
+
+def test_older_unpublished_version_is_rejected(tmp_path):
+    path = local_wheel(tmp_path)
+    def fetch(url, **kwargs):
+        return json.dumps({"info": {"version": "1.0.1"}}).encode() if url.endswith("/demo/json") else None
+    with pytest.raises(guard.GuardError, match="above the latest"):
+        guard.check_wheel(path, "demo", "1.0.0", fetcher=fetch)
+
+
+@pytest.mark.parametrize("options,match", [
+    ({"yanked": True}, "non-yanked"),
+    ({"digest": "0" * 64}, "SHA-256"),
+    ({"filename": "other.whl"}, "matching"),
+])
+def test_invalid_published_artifact_fails_closed(tmp_path, options, match):
+    path = local_wheel(tmp_path)
+    options = {"filename": path.name, **options}
+    with pytest.raises(guard.GuardError, match=match):
+        guard.check_wheel(path, "demo", "1.0.0", fetcher=published_fetcher(wheel(), **options))
+
+
+@pytest.mark.parametrize("error", [URLError("offline"), HTTPError("https://pypi.org", 503, "down", {}, None)])
+def test_pypi_unavailable_is_not_treated_as_new_version(error):
+    with patch.object(guard, "urlopen", side_effect=error), patch.object(guard.time, "sleep"):
+        with pytest.raises(guard.GuardError, match="refusing to release"):
+            guard.fetch("https://pypi.org/pypi/demo/1.0.0/json", missing_ok=True)
+
+
+def test_404_is_distinct_from_auth_failure():
+    for status in (404, 403):
+        with patch.object(guard, "urlopen", side_effect=HTTPError("https://pypi.org", status, "error", {}, None)):
+            if status == 404:
+                assert guard.fetch("https://pypi.org", missing_ok=True) is None
+            else:
+                with pytest.raises(guard.GuardError):
+                    guard.fetch("https://pypi.org", missing_ok=True)
+
+
+def test_wheel_identity_must_match_project(tmp_path):
+    path = local_wheel(tmp_path)
+    with pytest.raises(guard.GuardError, match="identity"):
+        guard.check_wheel(path, "other-package", "1.0.0")
+
+
+def test_release_dependency_gates_and_postpublication_verification():
+    workflow = yaml.safe_load((ROOT / ".github/workflows/publish-pypi.yml").read_text())
+    jobs = workflow["jobs"]
+    # Default success() dependency handling must not be bypassed by always().
+    for name in ("publish", "deploy-hosted", "publish-registry"):
+        assert "if" not in jobs[name]
+    assert "deploy-hosted" in jobs["publish"]["needs"]
+    assert "test-and-build" in jobs["deploy-hosted"]["needs"]
+    assert "publish" not in jobs["deploy-hosted"]["needs"]
+    assert jobs["publish-registry"]["needs"] == "publish"
+    steps = jobs["test-and-build"]["steps"]
+    guard_step = next(i for i, step in enumerate(steps) if "check_published_version.py" in step.get("run", ""))
+    upload_step = next(i for i, step in enumerate(steps) if step.get("uses", "").startswith("actions/upload-artifact@"))
+    assert guard_step < upload_step
+    assert not steps[guard_step].get("continue-on-error", False)
+    assert "if" not in steps[guard_step]
+    steps = jobs["publish"]["steps"]
+    upload_step = next(i for i, step in enumerate(steps) if step.get("uses", "").startswith("pypa/gh-action-pypi-publish@"))
+    assert any("--require-published" in step.get("run", "") for step in steps[upload_step + 1:])


### PR DESCRIPTION
An unchanged version number could previously cause PyPI to silently skip changed package code, and PyPI could publish before a Cloudflare permission or deployment failure became visible. This change blocks both cases: every built package is compared with its existing published version before deployment, and PyPI now depends on successful deployment and live verification of all five hosted services.

The guard compares installed wheel contents, dependency/Python metadata, extras, entry points, and compatibility. It verifies the downloaded wheel hash and fails closed on unavailable or inconsistent PyPI data. Unchanged versions remain safe to skip; ZIP timestamps, builder metadata, and README prose do not require a bump. A post-publication check verifies the actual PyPI wheel, including skipped versions. The documented partial-failure order is now Cloudflare first, then PyPI and the registry.

Validation: 16 regression tests passed, covering stale code/dependencies/entry points, new versions, invalid or yanked artifacts, PyPI outages, and the release dependency gates. All nine packages were rebuilt locally and matched their current published versions. Both workflow files pass actionlint. A read-only PR/main workflow exercises the regression cases and rebuilds all nine packages against live PyPI; it has no deployment credentials and performs no publication.

No MCP runtime code, tool definitions, package versions, or Cloudflare resources are changed. The safeguards take effect on future release tags.
